### PR TITLE
Match branches on the head branch for the PR instead of the temporary PR checkout

### DIFF
--- a/__tests__/fixtures/branches.yml
+++ b/__tests__/fixtures/branches.yml
@@ -3,3 +3,6 @@ test-branch:
 
 feature-branch:
   - branch: "*/feature/*"
+
+bug-branch:
+  - branch: "{bug,fix}/*"

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -105,7 +105,7 @@ describe("run", () => {
   });
 
   it("adds labels based on the branch names that match the glob pattern", async () => {
-    github.context.ref = "test/testing-time";
+    github.context.payload.pull_request!.head = {ref: "test/testing-time"};
     usingLabelerConfigYaml("branches.yml");
     await run();
 
@@ -119,7 +119,7 @@ describe("run", () => {
   });
 
   it("adds labels based on branch names that match different glob patterns", async () => {
-    github.context.ref = "my/feature/that-i-like";
+    github.context.payload.pull_request!.head = {ref: "my/feature/that-i-like"};
     usingLabelerConfigYaml("branches.yml");
     await run();
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -105,7 +105,7 @@ describe("run", () => {
   });
 
   it("adds labels based on the branch names that match the glob pattern", async () => {
-    github.context.payload.pull_request!.head = {ref: "test/testing-time"};
+    github.context.payload.pull_request!.head = { ref: "test/testing-time" };
     usingLabelerConfigYaml("branches.yml");
     await run();
 
@@ -119,7 +119,9 @@ describe("run", () => {
   });
 
   it("adds labels based on branch names that match different glob patterns", async () => {
-    github.context.payload.pull_request!.head = {ref: "my/feature/that-i-like"};
+    github.context.payload.pull_request!.head = {
+      ref: "my/feature/that-i-like",
+    };
     usingLabelerConfigYaml("branches.yml");
     await run();
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -133,6 +133,20 @@ describe("run", () => {
       labels: ["feature-branch"],
     });
   });
+
+  it("it can support multiple branches by batching", async () => {
+    github.context.payload.pull_request!.head = { ref: "fix/123" };
+    usingLabelerConfigYaml("branches.yml");
+    await run();
+
+    expect(addLabelsMock).toHaveBeenCalledTimes(1);
+    expect(addLabelsMock).toHaveBeenCalledWith({
+      owner: "monalisa",
+      repo: "helloworld",
+      issue_number: 123,
+      labels: ["bug-branch"],
+    });
+  });
 });
 
 function usingLabelerConfigYaml(fixtureName: keyof typeof yamlFixtures): void {

--- a/dist/index.js
+++ b/dist/index.js
@@ -206,7 +206,9 @@ function checkAll(changedFiles, globs) {
 function checkBranch(glob) {
     const matcher = new minimatch_1.Minimatch(glob);
     const branchName = github.context.ref;
+    const branchName2 = github.context.payload.pull_request.head.ref;
     core.debug(` checking "branch" pattern against ${branchName}`);
+    core.debug(` - but we should be checking ${branchName2}`);
     core.debug(`  - ${printPattern(matcher)}`);
     if (!matcher.match(branchName)) {
         core.debug(`   ${printPattern(matcher)} did not match`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -205,10 +205,8 @@ function checkAll(changedFiles, globs) {
 }
 function checkBranch(glob) {
     const matcher = new minimatch_1.Minimatch(glob);
-    const branchName = github.context.ref;
-    const branchName2 = github.context.payload.pull_request.head.ref;
+    const branchName = github.context.payload.pull_request.head.ref;
     core.debug(` checking "branch" pattern against ${branchName}`);
-    core.debug(` - but we should be checking ${branchName2}`);
     core.debug(`  - ${printPattern(matcher)}`);
     if (!matcher.match(branchName)) {
         core.debug(`   ${printPattern(matcher)} did not match`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "labeler",
       "version": "3.0.2",
       "license": "MIT",
       "dependencies": {

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -216,10 +216,10 @@ function checkAll(changedFiles: string[], globs: string[]): boolean {
 
 function checkBranch(glob: string): boolean {
   const matcher = new Minimatch(glob);
-  const branchName = github.context.payload.pull_request!.head.ref;
+  const branchName = github.context.payload.pull_request?.head.ref;
   core.debug(` checking "branch" pattern against ${branchName}`);
   core.debug(`  - ${printPattern(matcher)}`);
-  if (!matcher.match(branchName)) {
+  if (branchName || !matcher.match(branchName)) {
     core.debug(`   ${printPattern(matcher)} did not match`);
     return false;
   }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -216,10 +216,8 @@ function checkAll(changedFiles: string[], globs: string[]): boolean {
 
 function checkBranch(glob: string): boolean {
   const matcher = new Minimatch(glob);
-  const branchName = github.context.ref;
-  const branchName2 = github.context.payload.pull_request!.head.ref;
+  const branchName = github.context.payload.pull_request!.head.ref;
   core.debug(` checking "branch" pattern against ${branchName}`);
-  core.debug(` - but we should be checking ${branchName2}`);
   core.debug(`  - ${printPattern(matcher)}`);
   if (!matcher.match(branchName)) {
     core.debug(`   ${printPattern(matcher)} did not match`);

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -217,8 +217,9 @@ function checkAll(changedFiles: string[], globs: string[]): boolean {
 function checkBranch(glob: string): boolean {
   const matcher = new Minimatch(glob);
   const branchName = github.context.ref;
+  const branchName2 = github.context.payload.pull_request!.head.ref;
   core.debug(` checking "branch" pattern against ${branchName}`);
-  core.debug(` - but we should be checking ${github.context.payload.pull_request.head.ref}`);
+  core.debug(` - but we should be checking ${branchName2}`);
   core.debug(`  - ${printPattern(matcher)}`);
   if (!matcher.match(branchName)) {
     core.debug(`   ${printPattern(matcher)} did not match`);

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -218,6 +218,7 @@ function checkBranch(glob: string): boolean {
   const matcher = new Minimatch(glob);
   const branchName = github.context.ref;
   core.debug(` checking "branch" pattern against ${branchName}`);
+  core.debug(` - but we should be checking ${github.context.payload.pull_request.head.ref}`);
   core.debug(`  - ${printPattern(matcher)}`);
   if (!matcher.match(branchName)) {
     core.debug(`   ${printPattern(matcher)} did not match`);


### PR DESCRIPTION
`github.context.ref` was producing something like `refs/pull/23/head`, which would not match.

Using `github.context.payload.pull_request.head.ref` resolves this for me and uses the branch name that I actually want to match on.