### PR TITLE
New config structure for labeler

### DIFF
--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -1,7 +1,13 @@
 export const context = {
   payload: {
     pull_request: {
-      number: 123
+      number: 123,
+      head: {
+        ref: 'head-branch-name'
+      },
+      base: {
+        ref: 'base-branch-name'
+      }
     }
   },
   repo: {

--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -1,17 +1,40 @@
-import {checkBranch} from '../src/branch';
+import {getBranchName, checkBranch} from '../src/branch';
 import * as github from '@actions/github';
 
 jest.mock('@actions/core');
 jest.mock('@actions/github');
 
-describe('checkBranch', () => {
-  describe('when a single pattern is provided', () => {
-    beforeEach(() => {
-      github.context.payload.pull_request!.head = {
-        ref: 'test/feature/123'
-      };
+describe('getBranchName', () => {
+  describe('when the pull requests base branch is requested', () => {
+    it('returns the base branch name', () => {
+      const result = getBranchName('base');
+      expect(result).toEqual('base-branch-name');
     });
+  });
 
+  describe('when the pull requests head branch is requested', () => {
+    it('returns the head branch name', () => {
+      const result = getBranchName('head');
+      expect(result).toEqual('head-branch-name');
+    });
+  });
+
+  describe('when no branch is specified', () => {
+    it('returns the head branch name', () => {
+      const result = getBranchName('base');
+      expect(result).toEqual('base-branch-name');
+    });
+  });
+});
+
+describe('checkBranch', () => {
+  beforeEach(() => {
+    github.context.payload.pull_request!.head = {
+      ref: 'test/feature/123'
+    };
+  });
+
+  describe('when a single pattern is provided', () => {
     describe('and the pattern matches the head branch', () => {
       it('returns true', () => {
         const result = checkBranch(['^test']);
@@ -28,12 +51,6 @@ describe('checkBranch', () => {
   });
 
   describe('when multiple patterns are provided', () => {
-    beforeEach(() => {
-      github.context.payload.pull_request!.head = {
-        ref: 'test/feature/123'
-      };
-    });
-
     describe('and at least one pattern matches', () => {
       it('returns true', () => {
         const result = checkBranch(['^test/', '^feature/']);

--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -32,6 +32,9 @@ describe('checkBranch', () => {
     github.context.payload.pull_request!.head = {
       ref: 'test/feature/123'
     };
+    github.context.payload.pull_request!.base = {
+      ref: 'main'
+    };
   });
 
   describe('when a single pattern is provided', () => {
@@ -69,6 +72,15 @@ describe('checkBranch', () => {
       it('returns false', () => {
         const result = checkBranch(['^feature/', '/test$']);
         expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('when the branch to check is specified as the base branch', () => {
+    describe('and the pattern matches the base branch', () => {
+      it('returns true', () => {
+        const result = checkBranch(['^main$'], 'base');
+        expect(result).toBe(true);
       });
     });
   });

--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -21,8 +21,8 @@ describe('getBranchName', () => {
 
   describe('when no branch is specified', () => {
     it('returns the head branch name', () => {
-      const result = getBranchName('base');
-      expect(result).toEqual('base-branch-name');
+      const result = getBranchName();
+      expect(result).toEqual('head-branch-name');
     });
   });
 });

--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -1,4 +1,9 @@
-import {getBranchName, checkBranch} from '../src/branch';
+import {
+  getBranchName,
+  checkBranch,
+  toBranchMatchConfig,
+  BranchMatchConfig
+} from '../src/branch';
 import * as github from '@actions/github';
 
 jest.mock('@actions/core');
@@ -81,6 +86,69 @@ describe('checkBranch', () => {
       it('returns true', () => {
         const result = checkBranch(['^main$'], 'base');
         expect(result).toBe(true);
+      });
+    });
+  });
+});
+
+describe('toBranchMatchConfig', () => {
+  describe('when there are no branch keys in the config', () => {
+    const config = {'changed-files': [{any: ['testing']}]};
+    it('returns an empty object', () => {
+      const result = toBranchMatchConfig(config);
+      expect(result).toMatchObject({});
+    });
+  });
+
+  describe('when the config contains a head-branch option', () => {
+    const config = {'head-branch': ['testing']};
+    it('sets headBranch in the matchConfig', () => {
+      const result = toBranchMatchConfig(config);
+      expect(result).toMatchObject<BranchMatchConfig>({
+        headBranch: ['testing']
+      });
+    });
+
+    describe('and the matching option is a string', () => {
+      const stringConfig = {'head-branch': 'testing'};
+
+      it('sets headBranch in the matchConfig', () => {
+        const result = toBranchMatchConfig(stringConfig);
+        expect(result).toMatchObject<BranchMatchConfig>({
+          headBranch: ['testing']
+        });
+      });
+    });
+  });
+
+  describe('when the config contains a base-branch option', () => {
+    const config = {'base-branch': ['testing']};
+    it('sets headBranch in the matchConfig', () => {
+      const result = toBranchMatchConfig(config);
+      expect(result).toMatchObject<BranchMatchConfig>({
+        baseBranch: ['testing']
+      });
+    });
+
+    describe('and the matching option is a string', () => {
+      const stringConfig = {'base-branch': 'testing'};
+
+      it('sets headBranch in the matchConfig', () => {
+        const result = toBranchMatchConfig(stringConfig);
+        expect(result).toMatchObject<BranchMatchConfig>({
+          baseBranch: ['testing']
+        });
+      });
+    });
+  });
+
+  describe('when the config contains both a base-branch and head-branch option', () => {
+    const config = {'base-branch': ['testing'], 'head-branch': ['testing']};
+    it('sets headBranch in the matchConfig', () => {
+      const result = toBranchMatchConfig(config);
+      expect(result).toMatchObject<BranchMatchConfig>({
+        baseBranch: ['testing'],
+        headBranch: ['testing']
       });
     });
   });

--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -1,0 +1,58 @@
+import {checkBranch} from '../src/branch';
+import * as github from '@actions/github';
+
+jest.mock('@actions/core');
+jest.mock('@actions/github');
+
+describe('checkBranch', () => {
+  describe('when a single pattern is provided', () => {
+    beforeEach(() => {
+      github.context.payload.pull_request!.head = {
+        ref: 'test/feature/123'
+      };
+    });
+
+    describe('and the pattern matches the head branch', () => {
+      it('returns true', () => {
+        const result = checkBranch(['^test']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and the pattern does not match the head branch', () => {
+      it('returns false', () => {
+        const result = checkBranch(['^feature/']);
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('when multiple patterns are provided', () => {
+    beforeEach(() => {
+      github.context.payload.pull_request!.head = {
+        ref: 'test/feature/123'
+      };
+    });
+
+    describe('and at least one pattern matches', () => {
+      it('returns true', () => {
+        const result = checkBranch(['^test/', '^feature/']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and all patterns match', () => {
+      it('returns true', () => {
+        const result = checkBranch(['^test/', '/feature/']);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and no patterns match', () => {
+      it('returns false', () => {
+        const result = checkBranch(['^feature/', '/test$']);
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/__tests__/fixtures/branches.yml
+++ b/__tests__/fixtures/branches.yml
@@ -1,11 +1,11 @@
 test-branch:
-  - branch: "^test/"
+  - head-branch: "^test/"
 
 feature-branch:
-  - branch: "/feature/"
+  - head-branch: "/feature/"
 
 bug-branch:
-  - branch: "^bug/|fix/"
+  - head-branch: "^bug/|fix/"
 
 array-branch:
-  - branch: ["^array/"]
+  - head-branch: ["^array/"]

--- a/__tests__/fixtures/branches.yml
+++ b/__tests__/fixtures/branches.yml
@@ -1,11 +1,11 @@
 test-branch:
-  - branch: "test/**"
+  - branch: "^test/"
 
 feature-branch:
-  - branch: "*/feature/*"
+  - branch: "/feature/"
 
 bug-branch:
-  - branch: "{bug,fix}/*"
+  - branch: "^bug/|fix/"
 
 array-branch:
-  - branch: ["array/*"]
+  - branch: ["^array/"]

--- a/__tests__/fixtures/only_pdfs.yml
+++ b/__tests__/fixtures/only_pdfs.yml
@@ -1,2 +1,3 @@
 touched-a-pdf-file:
-  - any: ['*.pdf']
+  - changed-files:
+    - any: ['*.pdf']

--- a/__tests__/labeler.test.ts
+++ b/__tests__/labeler.test.ts
@@ -10,7 +10,8 @@ beforeAll(() => {
   });
 });
 
-// I have to double cast here as this is what comes from js-yaml looks like which then gets transformed in toMatchConfig
+// I have to double cast here as this is what the output from js-yaml looks like which then gets
+// transformed in toMatchConfig
 const matchConfig = [
   {'changed-files': [{any: ['*.txt']}]}
 ] as unknown as MatchConfig[];

--- a/__tests__/labeler.test.ts
+++ b/__tests__/labeler.test.ts
@@ -10,7 +10,7 @@ beforeAll(() => {
   });
 });
 
-const matchConfig = [{any: ['*.txt']}];
+const matchConfig = [{changedFiles: {any: ['*.txt']}}];
 
 describe('checkGlobs', () => {
   it('returns true when our pattern does match changed files', () => {

--- a/__tests__/labeler.test.ts
+++ b/__tests__/labeler.test.ts
@@ -1,4 +1,4 @@
-import {checkGlobs} from '../src/labeler';
+import {checkGlobs, MatchConfig} from '../src/labeler';
 
 import * as core from '@actions/core';
 
@@ -10,7 +10,10 @@ beforeAll(() => {
   });
 });
 
-const matchConfig = [{changedFiles: {any: ['*.txt']}}];
+// I have to double cast here as this is what comes from js-yaml looks like which then gets transformed in toMatchConfig
+const matchConfig = [
+  {'changed-files': [{any: ['*.txt']}]}
+] as unknown as MatchConfig[];
 
 describe('checkGlobs', () => {
   it('returns true when our pattern does match changed files', () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -104,7 +104,7 @@ describe('run', () => {
     expect(removeLabelMock).toHaveBeenCalledTimes(0);
   });
 
-  it('adds labels based on the branch names that match the glob pattern', async () => {
+  it('adds labels based on the branch names that match the regexp pattern', async () => {
     github.context.payload.pull_request!.head = {ref: 'test/testing-time'};
     usingLabelerConfigYaml('branches.yml');
     await run();
@@ -118,7 +118,7 @@ describe('run', () => {
     });
   });
 
-  it('adds multiple labels based on branch names that match different glob patterns', async () => {
+  it('adds multiple labels based on branch names that match different regexp patterns', async () => {
     github.context.payload.pull_request!.head = {
       ref: 'test/feature/123'
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -273,8 +273,14 @@ function toChangedFilesMatchConfig(config) {
         else {
             // If it is not an array of strings then it should be array of further config options
             // so assign them to our `changedFilesMatchConfig`
-            changedFilesConfig.forEach(element => {
-                Object.assign(changedFilesMatchConfig.changedFiles, element);
+            changedFilesConfig.forEach(config => {
+                // Make sure that the values that we assign to our match config are an array
+                Object.entries(config).forEach(([key, value]) => {
+                    const element = {
+                        [key]: Array.isArray(value) ? value : [value]
+                    };
+                    Object.assign(changedFilesMatchConfig.changedFiles, element);
+                });
             });
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,106 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ 8045:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.checkBranch = exports.getBranchName = exports.toBranchMatchConfig = void 0;
+const core = __importStar(__nccwpck_require__(2186));
+const github = __importStar(__nccwpck_require__(5438));
+function toBranchMatchConfig(config) {
+    if (!config['head-branch'] || config['base-branch']) {
+        return {};
+    }
+    const branchConfig = {
+        headBranch: config['head-branch'],
+        baseBranch: config['base-branch']
+    };
+    if (branchConfig.headBranch) {
+        const patterns = branchConfig.headBranch;
+        if (typeof patterns === 'string') {
+            branchConfig.headBranch = [patterns];
+        }
+    }
+    if (branchConfig.baseBranch) {
+        const patterns = branchConfig.baseBranch;
+        if (typeof patterns === 'string') {
+            branchConfig.baseBranch = [patterns];
+        }
+    }
+    return branchConfig;
+}
+exports.toBranchMatchConfig = toBranchMatchConfig;
+function getBranchName(branchBase) {
+    var _a, _b;
+    const pullRequest = github.context.payload.pull_request;
+    if (!pullRequest) {
+        return undefined;
+    }
+    if (branchBase === 'base') {
+        return (_a = pullRequest.base) === null || _a === void 0 ? void 0 : _a.ref;
+    }
+    else {
+        return (_b = pullRequest.head) === null || _b === void 0 ? void 0 : _b.ref;
+    }
+}
+exports.getBranchName = getBranchName;
+function checkBranch(glob, branchBase) {
+    const branchName = getBranchName(branchBase);
+    if (!branchName) {
+        core.debug(` no branch name`);
+        return false;
+    }
+    core.debug(` checking "branch" pattern against ${branchName}`);
+    const matchers = glob.map(g => new RegExp(g));
+    for (const matcher of matchers) {
+        if (matchBranchPattern(matcher, branchName)) {
+            core.debug(`  "branch" patterns matched against ${branchName}`);
+            return true;
+        }
+    }
+    core.debug(`  "branch" patterns did not match against ${branchName}`);
+    return false;
+}
+exports.checkBranch = checkBranch;
+function matchBranchPattern(matcher, branchName) {
+    core.debug(`  - ${matcher}`);
+    if (matcher.test(branchName)) {
+        core.debug(`   "branch" pattern matched`);
+        return true;
+    }
+    core.debug(`   ${matcher} did not match`);
+    return false;
+}
+
+
+/***/ }),
+
 /***/ 5272:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -44,6 +144,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const yaml = __importStar(__nccwpck_require__(1917));
 const minimatch_1 = __nccwpck_require__(3973);
+const branch_1 = __nccwpck_require__(8045);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -96,14 +197,6 @@ function getPrNumber() {
     }
     return pullRequest.number;
 }
-function getBranchName() {
-    var _a;
-    const pullRequest = github.context.payload.pull_request;
-    if (!pullRequest) {
-        return undefined;
-    }
-    return (_a = pullRequest.head) === null || _a === void 0 ? void 0 : _a.ref;
-}
 function getChangedFiles(client, prNumber) {
     return __awaiter(this, void 0, void 0, function* () {
         const listFilesOptions = client.rest.pulls.listFiles.endpoint.merge({
@@ -155,13 +248,42 @@ function getLabelGlobMapFromObject(configObject) {
     }
     return labelGlobs;
 }
-function toMatchConfig(config) {
-    if (typeof config === 'string') {
+function toChangedFilesMatchConfig(config) {
+    if (!config['changed-files']) {
+        return {};
+    }
+    const changedFiles = config['changed-files'];
+    // If the value provided is a string or an array of strings then default to `any` matching
+    if (typeof changedFiles === 'string') {
         return {
-            any: [config]
+            changedFiles: {
+                any: [changedFiles]
+            }
         };
     }
-    return config;
+    const changedFilesMatchConfig = {
+        changedFiles: {}
+    };
+    if (Array.isArray(changedFiles)) {
+        if (changedFiles.every(entry => typeof entry === 'string')) {
+            changedFilesMatchConfig.changedFiles = {
+                any: changedFiles
+            };
+        }
+        else {
+            // If it is not an array of strings then it should be array of further config options
+            // so assign them to our `changedFilesMatchConfig`
+            changedFiles.forEach(element => {
+                Object.assign(changedFilesMatchConfig.changedFiles, element);
+            });
+        }
+    }
+    return changedFilesMatchConfig;
+}
+function toMatchConfig(config) {
+    const changedFilesConfig = toChangedFilesMatchConfig(config);
+    const branchConfig = (0, branch_1.toBranchMatchConfig)(config);
+    return Object.assign(Object.assign({}, changedFilesConfig), branchConfig);
 }
 function printPattern(matcher) {
     return (matcher.negate ? '!' : '') + matcher.pattern;
@@ -215,51 +337,25 @@ function checkAll(changedFiles, globs) {
     core.debug(`  "all" patterns matched all files`);
     return true;
 }
-function matchBranchPattern(matcher, branchName) {
-    core.debug(`  - ${printPattern(matcher)}`);
-    if (matcher.match(branchName)) {
-        core.debug(`   "branch" pattern matched`);
-        return true;
-    }
-    core.debug(`   ${printPattern(matcher)} did not match`);
-    return false;
-}
-function checkBranch(glob) {
-    const branchName = getBranchName();
-    if (!branchName) {
-        core.debug(` no branch name`);
-        return false;
-    }
-    core.debug(` checking "branch" pattern against ${branchName}`);
-    if (Array.isArray(glob)) {
-        const matchers = glob.map(g => new minimatch_1.Minimatch(g));
-        for (const matcher of matchers) {
-            if (matchBranchPattern(matcher, branchName)) {
-                core.debug(`  "branch" patterns matched against ${branchName}`);
-                return true;
-            }
-        }
-        core.debug(`  "branch" patterns did not match against ${branchName}`);
-        return false;
-    }
-    else {
-        const matcher = new minimatch_1.Minimatch(glob);
-        return matchBranchPattern(matcher, branchName);
-    }
-}
 function checkMatch(changedFiles, matchConfig) {
-    if (matchConfig.all !== undefined) {
-        if (!checkAll(changedFiles, matchConfig.all)) {
+    var _a, _b;
+    if (((_a = matchConfig.changedFiles) === null || _a === void 0 ? void 0 : _a.all) !== undefined) {
+        if (!checkAll(changedFiles, matchConfig.changedFiles.all)) {
             return false;
         }
     }
-    if (matchConfig.any !== undefined) {
-        if (!checkAny(changedFiles, matchConfig.any)) {
+    if (((_b = matchConfig.changedFiles) === null || _b === void 0 ? void 0 : _b.any) !== undefined) {
+        if (!checkAny(changedFiles, matchConfig.changedFiles.any)) {
             return false;
         }
     }
-    if (matchConfig.branch !== undefined) {
-        if (!checkBranch(matchConfig.branch)) {
+    if (matchConfig.headBranch !== undefined) {
+        if (!(0, branch_1.checkBranch)(matchConfig.headBranch, 'head')) {
+            return false;
+        }
+    }
+    if (matchConfig.baseBranch !== undefined) {
+        if (!(0, branch_1.checkBranch)(matchConfig.baseBranch, 'base')) {
             return false;
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -34,7 +34,7 @@ exports.checkBranch = exports.getBranchName = exports.toBranchMatchConfig = void
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 function toBranchMatchConfig(config) {
-    if (!config['head-branch'] || config['base-branch']) {
+    if (!config['head-branch'] && !config['base-branch']) {
         return {};
     }
     const branchConfig = {
@@ -340,26 +340,26 @@ function checkAll(changedFiles, globs) {
 function checkMatch(changedFiles, matchConfig) {
     var _a, _b;
     if (((_a = matchConfig.changedFiles) === null || _a === void 0 ? void 0 : _a.all) !== undefined) {
-        if (!checkAll(changedFiles, matchConfig.changedFiles.all)) {
-            return false;
+        if (checkAll(changedFiles, matchConfig.changedFiles.all)) {
+            return true;
         }
     }
     if (((_b = matchConfig.changedFiles) === null || _b === void 0 ? void 0 : _b.any) !== undefined) {
-        if (!checkAny(changedFiles, matchConfig.changedFiles.any)) {
-            return false;
+        if (checkAny(changedFiles, matchConfig.changedFiles.any)) {
+            return true;
         }
     }
     if (matchConfig.headBranch !== undefined) {
-        if (!(0, branch_1.checkBranch)(matchConfig.headBranch, 'head')) {
-            return false;
+        if ((0, branch_1.checkBranch)(matchConfig.headBranch, 'head')) {
+            return true;
         }
     }
     if (matchConfig.baseBranch !== undefined) {
-        if (!(0, branch_1.checkBranch)(matchConfig.baseBranch, 'base')) {
-            return false;
+        if ((0, branch_1.checkBranch)(matchConfig.baseBranch, 'base')) {
+            return true;
         }
     }
-    return true;
+    return false;
 }
 function addLabels(client, prNumber, labels) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -48,7 +48,10 @@ export function getBranchName(branchBase?: BranchBase): string | undefined {
   }
 }
 
-export function checkBranch(glob: string[], branchBase?: BranchBase): boolean {
+export function checkBranch(
+  regexps: string[],
+  branchBase?: BranchBase
+): boolean {
   const branchName = getBranchName(branchBase);
   if (!branchName) {
     core.debug(` no branch name`);
@@ -56,7 +59,7 @@ export function checkBranch(glob: string[], branchBase?: BranchBase): boolean {
   }
 
   core.debug(` checking "branch" pattern against ${branchName}`);
-  const matchers = glob.map(g => new RegExp(g));
+  const matchers = regexps.map(regexp => new RegExp(regexp));
   for (const matcher of matchers) {
     if (matchBranchPattern(matcher, branchName)) {
       core.debug(`  "branch" patterns matched against ${branchName}`);

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -10,7 +10,7 @@ type BranchBase = 'base' | 'head';
 
 export function toBranchMatchConfig(config: any): BranchMatchConfig {
   if (!config['head-branch'] || config['base-branch']) {
-    return config;
+    return {};
   }
 
   const branchConfig = {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -3,6 +3,38 @@ import * as github from '@actions/github';
 
 type BranchBase = 'base' | 'head';
 
+export function toMatchConfigWithBranches(config: any) {
+  if (!config['head-branch'] || config['base-branch']) {
+    return config;
+  }
+
+  const branchConfig = {
+    headBranch: config['head-branch'],
+    baseBranch: config['base-branch']
+  };
+
+  if (branchConfig.headBranch) {
+    const patterns = branchConfig.headBranch;
+    if (typeof patterns === 'string') {
+      branchConfig.headBranch = [patterns];
+    }
+  }
+
+  if (branchConfig.baseBranch) {
+    const patterns = branchConfig.baseBranch;
+    if (typeof patterns === 'string') {
+      branchConfig.baseBranch = [patterns];
+    }
+  }
+
+  return {
+    ...config,
+    ['head-branch']: undefined,
+    ['base-branch']: undefined,
+    ...branchConfig
+  };
+}
+
 export function getBranchName(branchBase?: BranchBase): string | undefined {
   const pullRequest = github.context.payload.pull_request;
   if (!pullRequest) {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,9 +1,14 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
+export interface BranchMatchConfig {
+  headBranch?: string[];
+  baseBranch?: string[];
+}
+
 type BranchBase = 'base' | 'head';
 
-export function toMatchConfigWithBranches(config: any) {
+export function toBranchMatchConfig(config: any): BranchMatchConfig {
   if (!config['head-branch'] || config['base-branch']) {
     return config;
   }
@@ -27,12 +32,7 @@ export function toMatchConfigWithBranches(config: any) {
     }
   }
 
-  return {
-    ...config,
-    ['head-branch']: undefined,
-    ['base-branch']: undefined,
-    ...branchConfig
-  };
+  return branchConfig;
 }
 
 export function getBranchName(branchBase?: BranchBase): string | undefined {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,17 +1,23 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-function getHeadBranchName(): string | undefined {
+type BranchBase = 'base' | 'head';
+
+export function getBranchName(branchBase?: BranchBase): string | undefined {
   const pullRequest = github.context.payload.pull_request;
   if (!pullRequest) {
     return undefined;
   }
 
-  return pullRequest.head?.ref;
+  if (branchBase === 'base') {
+    return pullRequest.base?.ref;
+  } else {
+    return pullRequest.head?.ref;
+  }
 }
 
-export function checkBranch(glob: string[]): boolean {
-  const branchName = getHeadBranchName();
+export function checkBranch(glob: string[], branchBase?: BranchBase): boolean {
+  const branchName = getBranchName(branchBase);
   if (!branchName) {
     core.debug(` no branch name`);
     return false;

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -1,0 +1,42 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+function getHeadBranchName(): string | undefined {
+  const pullRequest = github.context.payload.pull_request;
+  if (!pullRequest) {
+    return undefined;
+  }
+
+  return pullRequest.head?.ref;
+}
+
+export function checkBranch(glob: string[]): boolean {
+  const branchName = getHeadBranchName();
+  if (!branchName) {
+    core.debug(` no branch name`);
+    return false;
+  }
+
+  core.debug(` checking "branch" pattern against ${branchName}`);
+  const matchers = glob.map(g => new RegExp(g));
+  for (const matcher of matchers) {
+    if (matchBranchPattern(matcher, branchName)) {
+      core.debug(`  "branch" patterns matched against ${branchName}`);
+      return true;
+    }
+  }
+
+  core.debug(`  "branch" patterns did not match against ${branchName}`);
+  return false;
+}
+
+function matchBranchPattern(matcher: RegExp, branchName: string): boolean {
+  core.debug(`  - ${matcher}`);
+  if (matcher.test(branchName)) {
+    core.debug(`   "branch" pattern matched`);
+    return true;
+  }
+
+  core.debug(`   ${matcher} did not match`);
+  return false;
+}

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -9,7 +9,7 @@ export interface BranchMatchConfig {
 type BranchBase = 'base' | 'head';
 
 export function toBranchMatchConfig(config: any): BranchMatchConfig {
-  if (!config['head-branch'] || config['base-branch']) {
+  if (!config['head-branch'] && !config['base-branch']) {
     return {};
   }
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -256,30 +256,30 @@ function checkAll(changedFiles: string[], globs: string[]): boolean {
 
 function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {
   if (matchConfig.changedFiles?.all !== undefined) {
-    if (!checkAll(changedFiles, matchConfig.changedFiles.all)) {
-      return false;
+    if (checkAll(changedFiles, matchConfig.changedFiles.all)) {
+      return true;
     }
   }
 
   if (matchConfig.changedFiles?.any !== undefined) {
-    if (!checkAny(changedFiles, matchConfig.changedFiles.any)) {
-      return false;
+    if (checkAny(changedFiles, matchConfig.changedFiles.any)) {
+      return true;
     }
   }
 
   if (matchConfig.headBranch !== undefined) {
-    if (!checkBranch(matchConfig.headBranch, 'head')) {
-      return false;
+    if (checkBranch(matchConfig.headBranch, 'head')) {
+      return true;
     }
   }
 
   if (matchConfig.baseBranch !== undefined) {
-    if (!checkBranch(matchConfig.baseBranch, 'base')) {
-      return false;
+    if (checkBranch(matchConfig.baseBranch, 'base')) {
+      return true;
     }
   }
 
-  return true;
+  return false;
 }
 
 async function addLabels(

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -72,7 +72,7 @@ function getPrNumber(): number | undefined {
   return pullRequest.number;
 }
 
-function getBranchName(): string | undefined {
+function getHeadBranchName(): string | undefined {
   const pullRequest = github.context.payload.pull_request;
   if (!pullRequest) {
     return undefined;
@@ -235,7 +235,7 @@ function matchBranchPattern(matcher: IMinimatch, branchName: string): boolean {
 }
 
 function checkBranch(glob: string | string[]): boolean {
-  const branchName = getBranchName();
+  const branchName = getHeadBranchName();
   if (!branchName) {
     core.debug(` no branch name`);
     return false;

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import * as yaml from 'js-yaml';
-import {Minimatch, IMinimatch} from 'minimatch';
+import {Minimatch} from 'minimatch';
 
 import {checkBranch, toMatchConfigWithBranches} from './branch';
 
@@ -155,7 +155,7 @@ function toMatchConfig(config: StringOrMatchConfig): MatchConfig {
   return toMatchConfigWithBranches(config);
 }
 
-function printPattern(matcher: IMinimatch): string {
+function printPattern(matcher: Minimatch): string {
   return (matcher.negate ? '!' : '') + matcher.pattern;
 }
 
@@ -173,7 +173,7 @@ export function checkGlobs(
   return false;
 }
 
-function isMatch(changedFile: string, matchers: IMinimatch[]): boolean {
+function isMatch(changedFile: string, matchers: Minimatch[]): boolean {
   core.debug(`    matching patterns against file ${changedFile}`);
   for (const matcher of matchers) {
     core.debug(`   - ${printPattern(matcher)}`);

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -173,8 +173,14 @@ function toChangedFilesMatchConfig(config: any): ChangedFilesMatchConfig {
     } else {
       // If it is not an array of strings then it should be array of further config options
       // so assign them to our `changedFilesMatchConfig`
-      changedFilesConfig.forEach(element => {
-        Object.assign(changedFilesMatchConfig.changedFiles, element);
+      changedFilesConfig.forEach(config => {
+        // Make sure that the values that we assign to our match config are an array
+        Object.entries(config).forEach(([key, value]) => {
+          const element = {
+            [key]: Array.isArray(value) ? value : [value]
+          };
+          Object.assign(changedFilesMatchConfig.changedFiles, element);
+        });
       });
     }
   }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -3,6 +3,8 @@ import * as github from '@actions/github';
 import * as yaml from 'js-yaml';
 import {Minimatch, IMinimatch} from 'minimatch';
 
+import {checkBranch} from './branch';
+
 interface MatchConfig {
   all?: string[];
   any?: string[];
@@ -70,15 +72,6 @@ function getPrNumber(): number | undefined {
   }
 
   return pullRequest.number;
-}
-
-function getHeadBranchName(): string | undefined {
-  const pullRequest = github.context.payload.pull_request;
-  if (!pullRequest) {
-    return undefined;
-  }
-
-  return pullRequest.head?.ref;
 }
 
 async function getChangedFiles(
@@ -226,37 +219,6 @@ function checkAll(changedFiles: string[], globs: string[]): boolean {
 
   core.debug(`  "all" patterns matched all files`);
   return true;
-}
-
-function matchBranchPattern(matcher: RegExp, branchName: string): boolean {
-  core.debug(`  - ${matcher}`);
-  if (matcher.test(branchName)) {
-    core.debug(`   "branch" pattern matched`);
-    return true;
-  }
-
-  core.debug(`   ${matcher} did not match`);
-  return false;
-}
-
-function checkBranch(glob: string[]): boolean {
-  const branchName = getHeadBranchName();
-  if (!branchName) {
-    core.debug(` no branch name`);
-    return false;
-  }
-
-  core.debug(` checking "branch" pattern against ${branchName}`);
-  const matchers = glob.map(g => new RegExp(g));
-  for (const matcher of matchers) {
-    if (matchBranchPattern(matcher, branchName)) {
-      core.debug(`  "branch" patterns matched against ${branchName}`);
-      return true;
-    }
-  }
-
-  core.debug(`  "branch" patterns did not match against ${branchName}`);
-  return false;
 }
 
 function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -3,12 +3,11 @@ import * as github from '@actions/github';
 import * as yaml from 'js-yaml';
 import {Minimatch, IMinimatch} from 'minimatch';
 
-import {checkBranch} from './branch';
+import {checkBranch, toMatchConfigWithBranches} from './branch';
 
 interface MatchConfig {
   all?: string[];
   any?: string[];
-  branch?: string[];
   headBranch?: string[];
   baseBranch?: string[];
 }
@@ -151,14 +150,9 @@ function toMatchConfig(config: StringOrMatchConfig): MatchConfig {
     return {
       any: [config]
     };
-  } else if (typeof config.branch === 'string') {
-    return {
-      ...config,
-      branch: [config.branch]
-    };
   }
 
-  return config;
+  return toMatchConfigWithBranches(config);
 }
 
 function printPattern(matcher: IMinimatch): string {
@@ -232,12 +226,6 @@ function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {
 
   if (matchConfig.any !== undefined) {
     if (!checkAny(changedFiles, matchConfig.any)) {
-      return false;
-    }
-  }
-
-  if (matchConfig.branch !== undefined) {
-    if (!checkBranch(matchConfig.branch)) {
       return false;
     }
   }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -9,6 +9,8 @@ interface MatchConfig {
   all?: string[];
   any?: string[];
   branch?: string[];
+  headBranch?: string[];
+  baseBranch?: string[];
 }
 
 type StringOrMatchConfig = string | MatchConfig;
@@ -236,6 +238,18 @@ function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {
 
   if (matchConfig.branch !== undefined) {
     if (!checkBranch(matchConfig.branch)) {
+      return false;
+    }
+  }
+
+  if (matchConfig.headBranch !== undefined) {
+    if (!checkBranch(matchConfig.headBranch, 'head')) {
+      return false;
+    }
+  }
+
+  if (matchConfig.baseBranch !== undefined) {
+    if (!checkBranch(matchConfig.baseBranch, 'base')) {
       return false;
     }
   }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -3,14 +3,18 @@ import * as github from '@actions/github';
 import * as yaml from 'js-yaml';
 import {Minimatch} from 'minimatch';
 
-import {checkBranch, toMatchConfigWithBranches} from './branch';
+import {checkBranch, toBranchMatchConfig, BranchMatchConfig} from './branch';
 
-interface MatchConfig {
+interface FilesChangedMatchConfig {
   all?: string[];
   any?: string[];
-  headBranch?: string[];
-  baseBranch?: string[];
+  filesChanged?: {
+    all?: string[];
+    any?: string[];
+  };
 }
+
+type MatchConfig = FilesChangedMatchConfig & BranchMatchConfig;
 
 type StringOrMatchConfig = string | MatchConfig;
 type ClientType = ReturnType<typeof github.getOctokit>;
@@ -152,7 +156,12 @@ function toMatchConfig(config: StringOrMatchConfig): MatchConfig {
     };
   }
 
-  return toMatchConfigWithBranches(config);
+  const branchConfig = toBranchMatchConfig(config);
+
+  return {
+    ...config,
+    ...branchConfig
+  };
 }
 
 function printPattern(matcher: Minimatch): string {


### PR DESCRIPTION
**Description:**
Start of a new config structure for the `labeler` action - it no longer defaults to checking paths, you need to specify `changed-files` in your labeler config file. Also adds `head-branch` and `base-branch` options for adding labels based on those branch names.

Also moves all the branch checking related logic into it's own file and adds unit tests for that.

This is what the `labeler.yml` will end up looking like after these changes:
```yml
label:
  - changed-files:
    - any: ['list', 'of', 'globs']
    - all: ['list', 'of', 'globs']
  - base-branch: ['list', 'of', 'regexps']
  - head-branch: ['list', 'of', 'regexps']
```

---

🤔 I'm trying not to refactor more of this than I need to - but I wonder if this as it is is potentially going to make things a little bit more confusing for a while, partly because it was all written around the sole option of file changes and now that is not the only way to use this action. So there are things like globs being referenced in a lot of function names which is kinda weird now. 

And because we have nested options now and not each matchconfig individually in it's own item as a part of the map I'm reversing the conditions of `checkMatch` so that if any condition is successful then we apply the label rather than checking for all the options and if any fails then return.