### PR TITLE
Change the structure of the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ label1:
   - changed-files: ['example1/*']
 ```
 
-From a boolean logic perspective, top-level match objects are `AND`-ed together and individual match rules within an object are `OR`-ed. If path globs are combined with `!` negation, you can write complex matching rules.
+From a boolean logic perspective, top-level match objects, and options within `all`  are `AND`-ed together and individual match rules within the `any` object are `OR`-ed. If path globs are combined with `!` negation, you can write complex matching rules.
 
 #### Basic Examples
 

--- a/README.md
+++ b/README.md
@@ -14,27 +14,36 @@ The key is the name of the label in your repository that you want to add (eg: "m
 
 #### Match Object
 
-The match object allows control over the matching options, you can specify the label to be applied based on the files that have changed or the name of the branch. For the changed files options you provide a [path glob](https://github.com/isaacs/minimatch#minimatch), and a regexp for the branch names.
-The match object is defined as:
+The match object allows control over the matching options, you can specify the label to be applied based on the files that have changed or the name of either the base branch or the head branch. For the changed files options you provide a [path glob](https://github.com/isaacs/minimatch#minimatch), and for the branches you provide a regexp to match against the branch name.
 
+The base match object is defined as:
 ```yml
-- changed-files:
-  - any: ['list', 'of', 'globs']
-  - all: ['list', 'of', 'globs']
+- changed-files: ['list', 'of', 'globs']
 - base-branch: ['list', 'of', 'regexps']
 - head-branch: ['list', 'of', 'regexps']
 ```
 
-One or all fields can be provided for fine-grained matching. Unlike the top-level list, the list of path globs provided to `any` and `all` must ALL match against a path for the label to be applied.
+There are two top level keys of `any` and `all`, which both accept the same config options:
+```yml
+- any:
+  - changed-files: ['list', 'of', 'globs']
+  - base-branch: ['list', 'of', 'regexps']
+  - head-branch: ['list', 'of', 'regexps']
+- all:
+  - changed-files: ['list', 'of', 'globs']
+  - base-branch: ['list', 'of', 'regexps']
+  - head-branch: ['list', 'of', 'regexps']
+```
 
+One or all fields can be provided for fine-grained matching.
 The fields are defined as follows:
-* `changed-files`
-  * `any`: match ALL globs against ANY changed path
-  * `all`: match ALL globs against ALL changed paths
+* `all`: all of the provided options must match in order for the label to be applied
+* `any`: if any of the provided options match then a label will be applied
 * `base-branch`: match a regexp against the base branch name
+* `changed-files`: match a glob against the changed paths
 * `head-branch`: match a regexp against the head branch name
 
-A simple path glob is the equivalent to `any: ['glob']`. More specifically, the following two configurations are equivalent:
+If a base option is provided without a top-level key then it will default to `any`. More specifically, the following two configurations are equivalent:
 ```yml
 label1:
 - changed-files: example1/*
@@ -42,11 +51,11 @@ label1:
 and
 ```yml
 label1:
-- changed-files:
-  - any: ['example1/*']
+- any:
+  - changed-files: ['example1/*']
 ```
 
-From a boolean logic perspective, top-level match objects are `OR`-ed together and individual match rules within an object are `AND`-ed. Combined with `!` negation, you can write complex matching rules.
+From a boolean logic perspective, top-level match objects are `AND`-ed together and individual match rules within an object are `OR`-ed. If path globs are combined with `!` negation, you can write complex matching rules.
 
 #### Basic Examples
 
@@ -96,9 +105,10 @@ source:
 
 # Add 'frontend` label to any change to *.js files as long as the `main.js` hasn't changed
 frontend:
-- changed-files:
-  - any: ['src/**/*.js']
-    all: ['!src/main.js']
+- any:
+  - changed-files: ['src/**/*.js']
+- all:
+  - changed-files: ['!src/main.js']
 
  # Add 'feature' label to any PR where the head branch name starts with `feature` or has a `feature` section in the name
 feature:

--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -1,6 +1,7 @@
 import {
   getBranchName,
   checkAnyBranch,
+  checkAllBranch,
   toBranchMatchConfig,
   BranchMatchConfig
 } from '../src/branch';
@@ -21,6 +22,65 @@ describe('getBranchName', () => {
     it('returns the head branch name', () => {
       const result = getBranchName('head');
       expect(result).toEqual('head-branch-name');
+    });
+  });
+});
+
+describe('checkAllBranch', () => {
+  beforeEach(() => {
+    github.context.payload.pull_request!.head = {
+      ref: 'test/feature/123'
+    };
+    github.context.payload.pull_request!.base = {
+      ref: 'main'
+    };
+  });
+
+  describe('when a single pattern is provided', () => {
+    describe('and the pattern matches the head branch', () => {
+      it('returns true', () => {
+        const result = checkAllBranch(['^test'], 'head');
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and the pattern does not match the head branch', () => {
+      it('returns false', () => {
+        const result = checkAllBranch(['^feature/'], 'head');
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('when multiple patterns are provided', () => {
+    describe('and not all patterns matched', () => {
+      it('returns false', () => {
+        const result = checkAllBranch(['^test/', '^feature/'], 'head');
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('and all patterns match', () => {
+      it('returns true', () => {
+        const result = checkAllBranch(['^test/', '/feature/'], 'head');
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('and no patterns match', () => {
+      it('returns false', () => {
+        const result = checkAllBranch(['^feature/', '/test$'], 'head');
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('when the branch to check is specified as the base branch', () => {
+    describe('and the pattern matches the base branch', () => {
+      it('returns true', () => {
+        const result = checkAllBranch(['^main$'], 'base');
+        expect(result).toBe(true);
+      });
     });
   });
 });

--- a/__tests__/branch.test.ts
+++ b/__tests__/branch.test.ts
@@ -1,6 +1,6 @@
 import {
   getBranchName,
-  checkBranch,
+  checkAnyBranch,
   toBranchMatchConfig,
   BranchMatchConfig
 } from '../src/branch';
@@ -25,7 +25,7 @@ describe('getBranchName', () => {
   });
 });
 
-describe('checkBranch', () => {
+describe('checkAnyBranch', () => {
   beforeEach(() => {
     github.context.payload.pull_request!.head = {
       ref: 'test/feature/123'
@@ -38,14 +38,14 @@ describe('checkBranch', () => {
   describe('when a single pattern is provided', () => {
     describe('and the pattern matches the head branch', () => {
       it('returns true', () => {
-        const result = checkBranch(['^test'], 'head');
+        const result = checkAnyBranch(['^test'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and the pattern does not match the head branch', () => {
       it('returns false', () => {
-        const result = checkBranch(['^feature/'], 'head');
+        const result = checkAnyBranch(['^feature/'], 'head');
         expect(result).toBe(false);
       });
     });
@@ -54,21 +54,21 @@ describe('checkBranch', () => {
   describe('when multiple patterns are provided', () => {
     describe('and at least one pattern matches', () => {
       it('returns true', () => {
-        const result = checkBranch(['^test/', '^feature/'], 'head');
+        const result = checkAnyBranch(['^test/', '^feature/'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and all patterns match', () => {
       it('returns true', () => {
-        const result = checkBranch(['^test/', '/feature/'], 'head');
+        const result = checkAnyBranch(['^test/', '/feature/'], 'head');
         expect(result).toBe(true);
       });
     });
 
     describe('and no patterns match', () => {
       it('returns false', () => {
-        const result = checkBranch(['^feature/', '/test$'], 'head');
+        const result = checkAnyBranch(['^feature/', '/test$'], 'head');
         expect(result).toBe(false);
       });
     });
@@ -77,7 +77,7 @@ describe('checkBranch', () => {
   describe('when the branch to check is specified as the base branch', () => {
     describe('and the pattern matches the base branch', () => {
       it('returns true', () => {
-        const result = checkBranch(['^main$'], 'base');
+        const result = checkAnyBranch(['^main$'], 'base');
         expect(result).toBe(true);
       });
     });

--- a/__tests__/changedFiles.test.ts
+++ b/__tests__/changedFiles.test.ts
@@ -63,72 +63,13 @@ describe('toChangedFilesMatchConfig', () => {
   });
 
   describe(`when there is a 'changed-files' key in the config`, () => {
-    describe(`and both 'any' and 'all' keys are present`, () => {
-      const config = {'changed-files': [{all: 'testing'}, {any: 'testing'}]};
+    describe('and the value is an array of strings', () => {
+      const config = {'changed-files': ['testing']};
 
-      it('sets both values in the config object', () => {
+      it('sets the value in the config object', () => {
         const result = toChangedFilesMatchConfig(config);
         expect(result).toEqual<ChangedFilesMatchConfig>({
-          changedFiles: {
-            any: ['testing'],
-            all: ['testing']
-          }
-        });
-      });
-    });
-
-    describe(`and it contains a 'all' key`, () => {
-      describe('with a value of a string', () => {
-        const config = {'changed-files': [{all: 'testing'}]};
-
-        it('sets the value to be an array of strings in the config object', () => {
-          const result = toChangedFilesMatchConfig(config);
-          expect(result).toEqual<ChangedFilesMatchConfig>({
-            changedFiles: {
-              all: ['testing']
-            }
-          });
-        });
-      });
-
-      describe('with a value of an array of strings', () => {
-        const config = {'changed-files': [{all: ['testing']}]};
-
-        it('sets the value in the config object', () => {
-          const result = toChangedFilesMatchConfig(config);
-          expect(result).toEqual<ChangedFilesMatchConfig>({
-            changedFiles: {
-              all: ['testing']
-            }
-          });
-        });
-      });
-    });
-
-    describe(`and it contains a 'any' key`, () => {
-      describe('with a value of a string', () => {
-        const config = {'changed-files': [{any: 'testing'}]};
-
-        it('sets the value to be an array of strings on the config object', () => {
-          const result = toChangedFilesMatchConfig(config);
-          expect(result).toEqual<ChangedFilesMatchConfig>({
-            changedFiles: {
-              any: ['testing']
-            }
-          });
-        });
-      });
-
-      describe('with a value of an array of strings', () => {
-        const config = {'changed-files': [{any: ['testing']}]};
-
-        it('sets the value in the config object', () => {
-          const result = toChangedFilesMatchConfig(config);
-          expect(result).toEqual<ChangedFilesMatchConfig>({
-            changedFiles: {
-              any: ['testing']
-            }
-          });
+          changedFiles: ['testing']
         });
       });
     });
@@ -136,31 +77,16 @@ describe('toChangedFilesMatchConfig', () => {
     describe('and the value is a string', () => {
       const config = {'changed-files': 'testing'};
 
-      it(`sets the string as an array under an 'any' key`, () => {
+      it(`sets the string as an array in the config object`, () => {
         const result = toChangedFilesMatchConfig(config);
         expect(result).toEqual<ChangedFilesMatchConfig>({
-          changedFiles: {
-            any: ['testing']
-          }
+          changedFiles: ['testing']
         });
       });
     });
 
-    describe('and the value is an array of strings', () => {
-      const config = {'changed-files': ['testing']};
-
-      it(`sets the array under an 'any' key`, () => {
-        const result = toChangedFilesMatchConfig(config);
-        expect(result).toEqual<ChangedFilesMatchConfig>({
-          changedFiles: {
-            any: ['testing']
-          }
-        });
-      });
-    });
-
-    describe('but it has empty values', () => {
-      const config = {'changed-files': []};
+    describe('but the value is an empty string', () => {
+      const config = {'changed-files': ''};
 
       it(`returns an empty object`, () => {
         const result = toChangedFilesMatchConfig(config);
@@ -168,16 +94,12 @@ describe('toChangedFilesMatchConfig', () => {
       });
     });
 
-    describe('and there is an unknown value in the config', () => {
-      const config = {'changed-files': [{any: 'testing'}, {sneaky: 'test'}]};
+    describe('but the value is an empty array', () => {
+      const config = {'changed-files': []};
 
-      it(`does not set the value in the match config`, () => {
+      it(`returns an empty object`, () => {
         const result = toChangedFilesMatchConfig(config);
-        expect(result).toEqual<ChangedFilesMatchConfig>({
-          changedFiles: {
-            any: ['testing']
-          }
-        });
+        expect(result).toEqual<ChangedFilesMatchConfig>({});
       });
     });
   });

--- a/__tests__/changedFiles.test.ts
+++ b/__tests__/changedFiles.test.ts
@@ -1,21 +1,21 @@
 import {
   ChangedFilesMatchConfig,
-  checkAll,
-  checkAny,
+  checkAllChangedFiles,
+  checkAnyChangedFiles,
   toChangedFilesMatchConfig
 } from '../src/changedFiles';
 
 jest.mock('@actions/core');
 jest.mock('@actions/github');
 
-describe('checkAll', () => {
+describe('checkAllChangedFiles', () => {
   const changedFiles = ['foo.txt', 'bar.txt'];
 
   describe('when the globs match every file that has changed', () => {
     const globs = ['*.txt'];
 
     it('returns true', () => {
-      const result = checkAll(changedFiles, globs);
+      const result = checkAllChangedFiles(changedFiles, globs);
       expect(result).toBe(true);
     });
   });
@@ -24,20 +24,20 @@ describe('checkAll', () => {
     const globs = ['foo.txt'];
 
     it('returns false', () => {
-      const result = checkAll(changedFiles, globs);
+      const result = checkAllChangedFiles(changedFiles, globs);
       expect(result).toBe(false);
     });
   });
 });
 
-describe('checkAny', () => {
+describe('checkAnyChangedFiles', () => {
   const changedFiles = ['foo.txt', 'bar.txt'];
 
   describe('when the globs match any of the files that have changed', () => {
     const globs = ['foo.txt'];
 
     it('returns true', () => {
-      const result = checkAny(changedFiles, globs);
+      const result = checkAnyChangedFiles(changedFiles, globs);
       expect(result).toBe(true);
     });
   });
@@ -46,7 +46,7 @@ describe('checkAny', () => {
     const globs = ['*.md'];
 
     it('returns false', () => {
-      const result = checkAny(changedFiles, globs);
+      const result = checkAnyChangedFiles(changedFiles, globs);
       expect(result).toBe(false);
     });
   });

--- a/__tests__/fixtures/all_options.yml
+++ b/__tests__/fixtures/all_options.yml
@@ -1,0 +1,14 @@
+label1:
+  - any:
+      - changed-files: ['glob']
+      - head-branch: ['regexp']
+      - base-branch: ['regexp']
+  - all:
+      - changed-files: ['glob']
+      - head-branch: ['regexp']
+      - base-branch: ['regexp']
+
+label2:
+  - changed-files: ['glob']
+  - head-branch: ['regexp']
+  - base-branch: ['regexp']

--- a/__tests__/fixtures/only_pdfs.yml
+++ b/__tests__/fixtures/only_pdfs.yml
@@ -1,3 +1,2 @@
 touched-a-pdf-file:
-  - changed-files:
-      - any: ['*.pdf']
+  - changed-files: ['*.pdf']

--- a/__tests__/labeler.test.ts
+++ b/__tests__/labeler.test.ts
@@ -88,19 +88,53 @@ describe('toMatchConfig', () => {
 });
 
 describe('checkMatchConfigs', () => {
-  const matchConfig: MatchConfig[] = [{any: [{changedFiles: ['*.txt']}]}];
+  describe('when a single match config is provided', () => {
+    const matchConfig: MatchConfig[] = [{any: [{changedFiles: ['*.txt']}]}];
 
-  it('returns true when our pattern does match changed files', () => {
-    const changedFiles = ['foo.txt', 'bar.txt'];
-    const result = checkMatchConfigs(changedFiles, matchConfig);
+    it('returns true when our pattern does match changed files', () => {
+      const changedFiles = ['foo.txt', 'bar.txt'];
+      const result = checkMatchConfigs(changedFiles, matchConfig);
 
-    expect(result).toBeTruthy();
+      expect(result).toBeTruthy();
+    });
+
+    it('returns false when our pattern does not match changed files', () => {
+      const changedFiles = ['foo.docx'];
+      const result = checkMatchConfigs(changedFiles, matchConfig);
+
+      expect(result).toBeFalsy();
+    });
+
+    it('returns true when either the branch or changed files patter matches', () => {
+      const matchConfig: MatchConfig[] = [
+        {any: [{changedFiles: ['*.txt']}, {headBranch: ['some-branch']}]}
+      ];
+      const changedFiles = ['foo.txt', 'bar.txt'];
+
+      const result = checkMatchConfigs(changedFiles, matchConfig);
+      expect(result).toBe(true);
+    });
   });
 
-  it('returns false when our pattern does not match changed files', () => {
-    const changedFiles = ['foo.docx'];
-    const result = checkMatchConfigs(changedFiles, matchConfig);
+  describe('when multiple MatchConfigs are supplied', () => {
+    const matchConfig: MatchConfig[] = [
+      {any: [{changedFiles: ['*.txt']}]},
+      {any: [{headBranch: ['some-branch']}]}
+    ];
+    const changedFiles = ['foo.txt', 'bar.md'];
 
-    expect(result).toBeFalsy();
+    it('returns false when only one config matches', () => {
+      const result = checkMatchConfigs(changedFiles, matchConfig);
+      expect(result).toBe(false);
+    });
+
+    it('returns true when only both config matches', () => {
+      const matchConfig: MatchConfig[] = [
+        {any: [{changedFiles: ['*.txt']}]},
+        {any: [{headBranch: ['head-branch']}]}
+      ];
+      const result = checkMatchConfigs(changedFiles, matchConfig);
+      expect(result).toBe(true);
+    });
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -212,7 +212,6 @@ function isAllMatch(changedFile, matchers) {
 }
 function checkAnyChangedFiles(changedFiles, globs) {
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
-    core.debug(`  checking "any" patterns`);
     for (const changedFile of changedFiles) {
         if (isAnyMatch(changedFile, matchers)) {
             core.debug(`  "any" patterns matched against ${changedFile}`);
@@ -225,7 +224,6 @@ function checkAnyChangedFiles(changedFiles, globs) {
 exports.checkAnyChangedFiles = checkAnyChangedFiles;
 function checkAllChangedFiles(changedFiles, globs) {
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
-    core.debug(` checking "all" patterns`);
     for (const changedFile of changedFiles) {
         if (!isAllMatch(changedFile, matchers)) {
             core.debug(`  "all" patterns did not match against ${changedFile}`);
@@ -424,6 +422,7 @@ function checkMatchConfigs(changedFiles, matchConfigs) {
 exports.checkMatchConfigs = checkMatchConfigs;
 function checkMatch(changedFiles, matchConfig) {
     if (!Object.keys(matchConfig).length) {
+        core.debug(`  no "any" or "all" patterns to check`);
         return false;
     }
     if (matchConfig.all) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -187,9 +187,9 @@ function printPattern(matcher) {
     return (matcher.negate ? '!' : '') + matcher.pattern;
 }
 function isAnyMatch(changedFile, matchers) {
-    core.debug(`    matching patterns against file ${changedFile}`);
+    core.debug(`   matching patterns against file ${changedFile}`);
     for (const matcher of matchers) {
-        core.debug(`   - ${printPattern(matcher)}`);
+        core.debug(`    - ${printPattern(matcher)}`);
         if (matcher.match(changedFile)) {
             core.debug(`   ${printPattern(matcher)} matched`);
             return true;
@@ -199,9 +199,9 @@ function isAnyMatch(changedFile, matchers) {
     return false;
 }
 function isAllMatch(changedFile, matchers) {
-    core.debug(`    matching patterns against file ${changedFile}`);
+    core.debug(`   matching patterns against file ${changedFile}`);
     for (const matcher of matchers) {
-        core.debug(`   - ${printPattern(matcher)}`);
+        core.debug(`    - ${printPattern(matcher)}`);
         if (!matcher.match(changedFile)) {
             core.debug(`   ${printPattern(matcher)} did not match`);
             return false;

--- a/dist/index.js
+++ b/dist/index.js
@@ -66,7 +66,7 @@ exports.getBranchName = getBranchName;
 function checkAnyBranch(regexps, branchBase) {
     const branchName = getBranchName(branchBase);
     if (!branchName) {
-        core.debug(` no branch name`);
+        core.debug(`   no branch name`);
         return false;
     }
     core.debug(`   checking "branch" pattern against ${branchName}`);
@@ -84,7 +84,7 @@ exports.checkAnyBranch = checkAnyBranch;
 function checkAllBranch(regexps, branchBase) {
     const branchName = getBranchName(branchBase);
     if (!branchName) {
-        core.debug(` no branch name`);
+        core.debug(`   no branch name`);
         return false;
     }
     core.debug(`   checking "branch" pattern against ${branchName}`);
@@ -187,38 +187,38 @@ function printPattern(matcher) {
     return (matcher.negate ? '!' : '') + matcher.pattern;
 }
 function isAnyMatch(changedFile, matchers) {
-    core.debug(`   matching patterns against file ${changedFile}`);
+    core.debug(`    matching patterns against file ${changedFile}`);
     for (const matcher of matchers) {
-        core.debug(`    - ${printPattern(matcher)}`);
+        core.debug(`     - ${printPattern(matcher)}`);
         if (matcher.match(changedFile)) {
-            core.debug(`   ${printPattern(matcher)} matched`);
+            core.debug(`    ${printPattern(matcher)} matched`);
             return true;
         }
     }
-    core.debug(`   no patterns matched`);
+    core.debug(`    no patterns matched`);
     return false;
 }
 function isAllMatch(changedFile, matchers) {
-    core.debug(`   matching patterns against file ${changedFile}`);
+    core.debug(`    matching patterns against file ${changedFile}`);
     for (const matcher of matchers) {
-        core.debug(`    - ${printPattern(matcher)}`);
+        core.debug(`     - ${printPattern(matcher)}`);
         if (!matcher.match(changedFile)) {
-            core.debug(`   ${printPattern(matcher)} did not match`);
+            core.debug(`    ${printPattern(matcher)} did not match`);
             return false;
         }
     }
-    core.debug(`   all patterns matched`);
+    core.debug(`    all patterns matched`);
     return true;
 }
 function checkAnyChangedFiles(changedFiles, globs) {
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     for (const changedFile of changedFiles) {
         if (isAnyMatch(changedFile, matchers)) {
-            core.debug(`  "any" patterns matched against ${changedFile}`);
+            core.debug(`   "any" patterns matched against ${changedFile}`);
             return true;
         }
     }
-    core.debug(`  "any" patterns did not match any files`);
+    core.debug(`   "any" patterns did not match any files`);
     return false;
 }
 exports.checkAnyChangedFiles = checkAnyChangedFiles;
@@ -226,11 +226,11 @@ function checkAllChangedFiles(changedFiles, globs) {
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     for (const changedFile of changedFiles) {
         if (!isAllMatch(changedFile, matchers)) {
-            core.debug(`  "all" patterns did not match against ${changedFile}`);
+            core.debug(`   "all" patterns did not match against ${changedFile}`);
             return false;
         }
     }
-    core.debug(`  "all" patterns matched all files`);
+    core.debug(`   "all" patterns matched all files`);
     return true;
 }
 exports.checkAllChangedFiles = checkAllChangedFiles;
@@ -467,7 +467,7 @@ function checkAny(matchConfigs, changedFiles) {
 exports.checkAny = checkAny;
 // equivalent to "Array.every()" but expanded for debugging and clarity
 function checkAll(matchConfigs, changedFiles) {
-    core.debug(` checking "all" patterns`);
+    core.debug(`  checking "all" patterns`);
     if (!Object.keys(matchConfigs).length) {
         core.debug(`  no "all" patterns to check`);
         return false;
@@ -489,7 +489,7 @@ function checkAll(matchConfigs, changedFiles) {
             }
         }
     }
-    core.debug(`  "all" patterns matched all files`);
+    core.debug(`  "all" patterns matched all configs`);
     return true;
 }
 exports.checkAll = checkAll;

--- a/dist/index.js
+++ b/dist/index.js
@@ -91,11 +91,11 @@ function checkAllBranch(regexps, branchBase) {
     const matchers = regexps.map(regexp => new RegExp(regexp));
     for (const matcher of matchers) {
         if (!matchBranchPattern(matcher, branchName)) {
-            core.debug(`  "branch" patterns matched against ${branchName}`);
+            core.debug(`  "branch" patterns did not match against ${branchName}`);
             return false;
         }
     }
-    core.debug(`  "branch" patterns did not match against ${branchName}`);
+    core.debug(`  "branch" patterns matched against ${branchName}`);
     return true;
 }
 exports.checkAllBranch = checkAllBranch;
@@ -481,7 +481,7 @@ function checkAll(matchConfigs, changedFiles) {
         }
         if (matchConfig.changedFiles) {
             if ((0, changedFiles_1.checkAllChangedFiles)(changedFiles, matchConfig.changedFiles)) {
-                return true;
+                return false;
             }
         }
         if (matchConfig.headBranch) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -480,7 +480,7 @@ function checkAll(matchConfigs, changedFiles) {
             }
         }
         if (matchConfig.changedFiles) {
-            if ((0, changedFiles_1.checkAllChangedFiles)(changedFiles, matchConfig.changedFiles)) {
+            if (!(0, changedFiles_1.checkAllChangedFiles)(changedFiles, matchConfig.changedFiles)) {
                 return false;
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -69,15 +69,15 @@ function checkAnyBranch(regexps, branchBase) {
         core.debug(` no branch name`);
         return false;
     }
-    core.debug(` checking "branch" pattern against ${branchName}`);
+    core.debug(`   checking "branch" pattern against ${branchName}`);
     const matchers = regexps.map(regexp => new RegExp(regexp));
     for (const matcher of matchers) {
         if (matchBranchPattern(matcher, branchName)) {
-            core.debug(`  "branch" patterns matched against ${branchName}`);
+            core.debug(`   "branch" patterns matched against ${branchName}`);
             return true;
         }
     }
-    core.debug(`  "branch" patterns did not match against ${branchName}`);
+    core.debug(`   "branch" patterns did not match against ${branchName}`);
     return false;
 }
 exports.checkAnyBranch = checkAnyBranch;
@@ -87,25 +87,25 @@ function checkAllBranch(regexps, branchBase) {
         core.debug(` no branch name`);
         return false;
     }
-    core.debug(` checking "branch" pattern against ${branchName}`);
+    core.debug(`   checking "branch" pattern against ${branchName}`);
     const matchers = regexps.map(regexp => new RegExp(regexp));
     for (const matcher of matchers) {
         if (!matchBranchPattern(matcher, branchName)) {
-            core.debug(`  "branch" patterns did not match against ${branchName}`);
+            core.debug(`   "branch" patterns did not match against ${branchName}`);
             return false;
         }
     }
-    core.debug(`  "branch" patterns matched against ${branchName}`);
+    core.debug(`   "branch" patterns matched against ${branchName}`);
     return true;
 }
 exports.checkAllBranch = checkAllBranch;
 function matchBranchPattern(matcher, branchName) {
-    core.debug(`  - ${matcher}`);
+    core.debug(`    - ${matcher}`);
     if (matcher.test(branchName)) {
-        core.debug(`   "branch" pattern matched`);
+        core.debug(`    "branch" pattern matched`);
         return true;
     }
-    core.debug(`   ${matcher} did not match`);
+    core.debug(`    ${matcher} did not match`);
     return false;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -186,7 +186,19 @@ exports.toChangedFilesMatchConfig = toChangedFilesMatchConfig;
 function printPattern(matcher) {
     return (matcher.negate ? '!' : '') + matcher.pattern;
 }
-function isMatch(changedFile, matchers) {
+function isAnyMatch(changedFile, matchers) {
+    core.debug(`    matching patterns against file ${changedFile}`);
+    for (const matcher of matchers) {
+        core.debug(`   - ${printPattern(matcher)}`);
+        if (matcher.match(changedFile)) {
+            core.debug(`   ${printPattern(matcher)} matched`);
+            return true;
+        }
+    }
+    core.debug(`   no patterns matched`);
+    return false;
+}
+function isAllMatch(changedFile, matchers) {
     core.debug(`    matching patterns against file ${changedFile}`);
     for (const matcher of matchers) {
         core.debug(`   - ${printPattern(matcher)}`);
@@ -202,7 +214,7 @@ function checkAnyChangedFiles(changedFiles, globs) {
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     core.debug(`  checking "any" patterns`);
     for (const changedFile of changedFiles) {
-        if (isMatch(changedFile, matchers)) {
+        if (isAnyMatch(changedFile, matchers)) {
             core.debug(`  "any" patterns matched against ${changedFile}`);
             return true;
         }
@@ -215,7 +227,7 @@ function checkAllChangedFiles(changedFiles, globs) {
     const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     core.debug(` checking "all" patterns`);
     for (const changedFile of changedFiles) {
-        if (!isMatch(changedFile, matchers)) {
+        if (!isAllMatch(changedFile, matchers)) {
             core.debug(`  "all" patterns did not match against ${changedFile}`);
             return false;
         }

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -46,7 +46,7 @@ export function checkAnyBranch(
 ): boolean {
   const branchName = getBranchName(branchBase);
   if (!branchName) {
-    core.debug(` no branch name`);
+    core.debug(`   no branch name`);
     return false;
   }
 
@@ -69,7 +69,7 @@ export function checkAllBranch(
 ): boolean {
   const branchName = getBranchName(branchBase);
   if (!branchName) {
-    core.debug(` no branch name`);
+    core.debug(`   no branch name`);
     return false;
   }
 

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -50,16 +50,16 @@ export function checkAnyBranch(
     return false;
   }
 
-  core.debug(` checking "branch" pattern against ${branchName}`);
+  core.debug(`   checking "branch" pattern against ${branchName}`);
   const matchers = regexps.map(regexp => new RegExp(regexp));
   for (const matcher of matchers) {
     if (matchBranchPattern(matcher, branchName)) {
-      core.debug(`  "branch" patterns matched against ${branchName}`);
+      core.debug(`   "branch" patterns matched against ${branchName}`);
       return true;
     }
   }
 
-  core.debug(`  "branch" patterns did not match against ${branchName}`);
+  core.debug(`   "branch" patterns did not match against ${branchName}`);
   return false;
 }
 
@@ -73,26 +73,26 @@ export function checkAllBranch(
     return false;
   }
 
-  core.debug(` checking "branch" pattern against ${branchName}`);
+  core.debug(`   checking "branch" pattern against ${branchName}`);
   const matchers = regexps.map(regexp => new RegExp(regexp));
   for (const matcher of matchers) {
     if (!matchBranchPattern(matcher, branchName)) {
-      core.debug(`  "branch" patterns did not match against ${branchName}`);
+      core.debug(`   "branch" patterns did not match against ${branchName}`);
       return false;
     }
   }
 
-  core.debug(`  "branch" patterns matched against ${branchName}`);
+  core.debug(`   "branch" patterns matched against ${branchName}`);
   return true;
 }
 
 function matchBranchPattern(matcher: RegExp, branchName: string): boolean {
-  core.debug(`  - ${matcher}`);
+  core.debug(`    - ${matcher}`);
   if (matcher.test(branchName)) {
-    core.debug(`   "branch" pattern matched`);
+    core.debug(`    "branch" pattern matched`);
     return true;
   }
 
-  core.debug(`   ${matcher} did not match`);
+  core.debug(`    ${matcher} did not match`);
   return false;
 }

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -40,7 +40,7 @@ export function getBranchName(branchBase: BranchBase): string | undefined {
   }
 }
 
-export function checkBranch(
+export function checkAnyBranch(
   regexps: string[],
   branchBase: BranchBase
 ): boolean {
@@ -61,6 +61,29 @@ export function checkBranch(
 
   core.debug(`  "branch" patterns did not match against ${branchName}`);
   return false;
+}
+
+export function checkAllBranch(
+  regexps: string[],
+  branchBase: BranchBase
+): boolean {
+  const branchName = getBranchName(branchBase);
+  if (!branchName) {
+    core.debug(` no branch name`);
+    return false;
+  }
+
+  core.debug(` checking "branch" pattern against ${branchName}`);
+  const matchers = regexps.map(regexp => new RegExp(regexp));
+  for (const matcher of matchers) {
+    if (!matchBranchPattern(matcher, branchName)) {
+      core.debug(`  "branch" patterns matched against ${branchName}`);
+      return false;
+    }
+  }
+
+  core.debug(`  "branch" patterns did not match against ${branchName}`);
+  return true;
 }
 
 function matchBranchPattern(matcher: RegExp, branchName: string): boolean {

--- a/src/branch.ts
+++ b/src/branch.ts
@@ -77,12 +77,12 @@ export function checkAllBranch(
   const matchers = regexps.map(regexp => new RegExp(regexp));
   for (const matcher of matchers) {
     if (!matchBranchPattern(matcher, branchName)) {
-      core.debug(`  "branch" patterns matched against ${branchName}`);
+      core.debug(`  "branch" patterns did not match against ${branchName}`);
       return false;
     }
   }
 
-  core.debug(`  "branch" patterns did not match against ${branchName}`);
+  core.debug(`  "branch" patterns matched against ${branchName}`);
   return true;
 }
 

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -63,7 +63,6 @@ function isMatch(changedFile: string, matchers: Minimatch[]): boolean {
   return true;
 }
 
-// equivalent to "Array.some()" but expanded for debugging and clarity
 export function checkAnyChangedFiles(
   changedFiles: string[],
   globs: string[]
@@ -81,7 +80,6 @@ export function checkAnyChangedFiles(
   return false;
 }
 
-// equivalent to "Array.every()" but expanded for debugging and clarity
 export function checkAllChangedFiles(
   changedFiles: string[],
   globs: string[]

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -49,7 +49,21 @@ function printPattern(matcher: Minimatch): string {
   return (matcher.negate ? '!' : '') + matcher.pattern;
 }
 
-function isMatch(changedFile: string, matchers: Minimatch[]): boolean {
+function isAnyMatch(changedFile: string, matchers: Minimatch[]): boolean {
+  core.debug(`    matching patterns against file ${changedFile}`);
+  for (const matcher of matchers) {
+    core.debug(`   - ${printPattern(matcher)}`);
+    if (matcher.match(changedFile)) {
+      core.debug(`   ${printPattern(matcher)} matched`);
+      return true;
+    }
+  }
+
+  core.debug(`   no patterns matched`);
+  return false;
+}
+
+function isAllMatch(changedFile: string, matchers: Minimatch[]): boolean {
   core.debug(`    matching patterns against file ${changedFile}`);
   for (const matcher of matchers) {
     core.debug(`   - ${printPattern(matcher)}`);
@@ -70,7 +84,7 @@ export function checkAnyChangedFiles(
   const matchers = globs.map(g => new Minimatch(g));
   core.debug(`  checking "any" patterns`);
   for (const changedFile of changedFiles) {
-    if (isMatch(changedFile, matchers)) {
+    if (isAnyMatch(changedFile, matchers)) {
       core.debug(`  "any" patterns matched against ${changedFile}`);
       return true;
     }
@@ -87,7 +101,7 @@ export function checkAllChangedFiles(
   const matchers = globs.map(g => new Minimatch(g));
   core.debug(` checking "all" patterns`);
   for (const changedFile of changedFiles) {
-    if (!isMatch(changedFile, matchers)) {
+    if (!isAllMatch(changedFile, matchers)) {
       core.debug(`  "all" patterns did not match against ${changedFile}`);
       return false;
     }

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -64,7 +64,10 @@ function isMatch(changedFile: string, matchers: Minimatch[]): boolean {
 }
 
 // equivalent to "Array.some()" but expanded for debugging and clarity
-export function checkAny(changedFiles: string[], globs: string[]): boolean {
+export function checkAnyChangedFiles(
+  changedFiles: string[],
+  globs: string[]
+): boolean {
   const matchers = globs.map(g => new Minimatch(g));
   core.debug(`  checking "any" patterns`);
   for (const changedFile of changedFiles) {
@@ -79,7 +82,10 @@ export function checkAny(changedFiles: string[], globs: string[]): boolean {
 }
 
 // equivalent to "Array.every()" but expanded for debugging and clarity
-export function checkAll(changedFiles: string[], globs: string[]): boolean {
+export function checkAllChangedFiles(
+  changedFiles: string[],
+  globs: string[]
+): boolean {
   const matchers = globs.map(g => new Minimatch(g));
   core.debug(` checking "all" patterns`);
   for (const changedFile of changedFiles) {

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -82,7 +82,6 @@ export function checkAnyChangedFiles(
   globs: string[]
 ): boolean {
   const matchers = globs.map(g => new Minimatch(g));
-  core.debug(`  checking "any" patterns`);
   for (const changedFile of changedFiles) {
     if (isAnyMatch(changedFile, matchers)) {
       core.debug(`  "any" patterns matched against ${changedFile}`);
@@ -99,7 +98,6 @@ export function checkAllChangedFiles(
   globs: string[]
 ): boolean {
   const matchers = globs.map(g => new Minimatch(g));
-  core.debug(` checking "all" patterns`);
   for (const changedFile of changedFiles) {
     if (!isAllMatch(changedFile, matchers)) {
       core.debug(`  "all" patterns did not match against ${changedFile}`);

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -50,30 +50,30 @@ function printPattern(matcher: Minimatch): string {
 }
 
 function isAnyMatch(changedFile: string, matchers: Minimatch[]): boolean {
-  core.debug(`   matching patterns against file ${changedFile}`);
+  core.debug(`    matching patterns against file ${changedFile}`);
   for (const matcher of matchers) {
-    core.debug(`    - ${printPattern(matcher)}`);
+    core.debug(`     - ${printPattern(matcher)}`);
     if (matcher.match(changedFile)) {
-      core.debug(`   ${printPattern(matcher)} matched`);
+      core.debug(`    ${printPattern(matcher)} matched`);
       return true;
     }
   }
 
-  core.debug(`   no patterns matched`);
+  core.debug(`    no patterns matched`);
   return false;
 }
 
 function isAllMatch(changedFile: string, matchers: Minimatch[]): boolean {
-  core.debug(`   matching patterns against file ${changedFile}`);
+  core.debug(`    matching patterns against file ${changedFile}`);
   for (const matcher of matchers) {
-    core.debug(`    - ${printPattern(matcher)}`);
+    core.debug(`     - ${printPattern(matcher)}`);
     if (!matcher.match(changedFile)) {
-      core.debug(`   ${printPattern(matcher)} did not match`);
+      core.debug(`    ${printPattern(matcher)} did not match`);
       return false;
     }
   }
 
-  core.debug(`   all patterns matched`);
+  core.debug(`    all patterns matched`);
   return true;
 }
 
@@ -84,12 +84,12 @@ export function checkAnyChangedFiles(
   const matchers = globs.map(g => new Minimatch(g));
   for (const changedFile of changedFiles) {
     if (isAnyMatch(changedFile, matchers)) {
-      core.debug(`  "any" patterns matched against ${changedFile}`);
+      core.debug(`   "any" patterns matched against ${changedFile}`);
       return true;
     }
   }
 
-  core.debug(`  "any" patterns did not match any files`);
+  core.debug(`   "any" patterns did not match any files`);
   return false;
 }
 
@@ -100,11 +100,11 @@ export function checkAllChangedFiles(
   const matchers = globs.map(g => new Minimatch(g));
   for (const changedFile of changedFiles) {
     if (!isAllMatch(changedFile, matchers)) {
-      core.debug(`  "all" patterns did not match against ${changedFile}`);
+      core.debug(`   "all" patterns did not match against ${changedFile}`);
       return false;
     }
   }
 
-  core.debug(`  "all" patterns matched all files`);
+  core.debug(`   "all" patterns matched all files`);
   return true;
 }

--- a/src/changedFiles.ts
+++ b/src/changedFiles.ts
@@ -50,9 +50,9 @@ function printPattern(matcher: Minimatch): string {
 }
 
 function isAnyMatch(changedFile: string, matchers: Minimatch[]): boolean {
-  core.debug(`    matching patterns against file ${changedFile}`);
+  core.debug(`   matching patterns against file ${changedFile}`);
   for (const matcher of matchers) {
-    core.debug(`   - ${printPattern(matcher)}`);
+    core.debug(`    - ${printPattern(matcher)}`);
     if (matcher.match(changedFile)) {
       core.debug(`   ${printPattern(matcher)} matched`);
       return true;
@@ -64,9 +64,9 @@ function isAnyMatch(changedFile: string, matchers: Minimatch[]): boolean {
 }
 
 function isAllMatch(changedFile: string, matchers: Minimatch[]): boolean {
-  core.debug(`    matching patterns against file ${changedFile}`);
+  core.debug(`   matching patterns against file ${changedFile}`);
   for (const matcher of matchers) {
-    core.debug(`   - ${printPattern(matcher)}`);
+    core.debug(`    - ${printPattern(matcher)}`);
     if (!matcher.match(changedFile)) {
       core.debug(`   ${printPattern(matcher)} did not match`);
       return false;

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -274,7 +274,7 @@ export function checkAll(
 
     if (matchConfig.changedFiles) {
       if (checkAllChangedFiles(changedFiles, matchConfig.changedFiles)) {
-        return true;
+        return false;
       }
     }
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -273,7 +273,7 @@ export function checkAll(
     }
 
     if (matchConfig.changedFiles) {
-      if (checkAllChangedFiles(changedFiles, matchConfig.changedFiles)) {
+      if (!checkAllChangedFiles(changedFiles, matchConfig.changedFiles)) {
         return false;
       }
     }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -260,7 +260,7 @@ export function checkAll(
   matchConfigs: BaseMatchConfig[],
   changedFiles: string[]
 ): boolean {
-  core.debug(` checking "all" patterns`);
+  core.debug(`  checking "all" patterns`);
   if (!Object.keys(matchConfigs).length) {
     core.debug(`  no "all" patterns to check`);
     return false;
@@ -286,7 +286,7 @@ export function checkAll(
     }
   }
 
-  core.debug(`  "all" patterns matched all files`);
+  core.debug(`  "all" patterns matched all configs`);
   return true;
 }
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -5,9 +5,16 @@ import * as yaml from 'js-yaml';
 import {
   ChangedFilesMatchConfig,
   getChangedFiles,
-  toChangedFilesMatchConfig
+  toChangedFilesMatchConfig,
+  checkAllChangedFiles,
+  checkAnyChangedFiles
 } from './changedFiles';
-import {checkBranch, toBranchMatchConfig, BranchMatchConfig} from './branch';
+import {
+  checkAnyBranch,
+  checkAllBranch,
+  toBranchMatchConfig,
+  BranchMatchConfig
+} from './branch';
 
 export type BaseMatchConfig = BranchMatchConfig & ChangedFilesMatchConfig;
 
@@ -215,24 +222,24 @@ function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {
 // equivalent to "Array.some()" but expanded for debugging and clarity
 export function checkAny(
   matchConfigs: BaseMatchConfig[],
-  _changedFiles: string[]
+  changedFiles: string[]
 ): boolean {
   core.debug(`  checking "any" patterns`);
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
-      if (checkBranch(matchConfig.baseBranch, 'base')) {
+      if (checkAnyBranch(matchConfig.baseBranch, 'base')) {
         return true;
       }
     }
 
-    // if (matchConfig.changedFiles) {
-    //   if (checkFiles(matchConfig.changedFiles, changedFiles)) {
-    //     return true;
-    //   }
-    // }
+    if (matchConfig.changedFiles) {
+      if (checkAnyChangedFiles(changedFiles, matchConfig.changedFiles)) {
+        return true;
+      }
+    }
 
     if (matchConfig.headBranch) {
-      if (checkBranch(matchConfig.headBranch, 'head')) {
+      if (checkAnyBranch(matchConfig.headBranch, 'head')) {
         return true;
       }
     }
@@ -245,24 +252,24 @@ export function checkAny(
 // equivalent to "Array.every()" but expanded for debugging and clarity
 export function checkAll(
   matchConfigs: BaseMatchConfig[],
-  _changedFiles: string[]
+  changedFiles: string[]
 ): boolean {
   core.debug(` checking "all" patterns`);
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
-      if (!checkBranch(matchConfig.baseBranch, 'base')) {
+      if (!checkAllBranch(matchConfig.baseBranch, 'base')) {
         return false;
       }
     }
 
-    // if (matchConfig.changedFiles) {
-    //   if (checkFiles(matchConfig.changedFiles, changedFiles)) {
-    //     return true;
-    //   }
-    // }
+    if (matchConfig.changedFiles) {
+      if (checkAllChangedFiles(changedFiles, matchConfig.changedFiles)) {
+        return true;
+      }
+    }
 
     if (matchConfig.headBranch) {
-      if (!checkBranch(matchConfig.headBranch, 'head')) {
+      if (!checkAllBranch(matchConfig.headBranch, 'head')) {
         return false;
       }
     }

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -201,6 +201,7 @@ export function checkMatchConfigs(
 
 function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {
   if (!Object.keys(matchConfig).length) {
+    core.debug(`  no "any" or "all" patterns to check`);
     return false;
   }
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -167,7 +167,9 @@ export function getLabelConfigMapFromObject(
       []
     );
 
-    labelMap.set(label, matchConfigs);
+    if (matchConfigs.length) {
+      labelMap.set(label, matchConfigs);
+    }
   }
 
   return labelMap;
@@ -203,16 +205,14 @@ function checkMatch(changedFiles: string[], matchConfig: MatchConfig): boolean {
   }
 
   if (matchConfig.all) {
-    // check the options and if anything fails then return false
     if (!checkAll(matchConfig.all, changedFiles)) {
       return false;
     }
   }
 
   if (matchConfig.any) {
-    // Check all the various options if any pass return true
-    if (checkAny(matchConfig.any, changedFiles)) {
-      return true;
+    if (!checkAny(matchConfig.any, changedFiles)) {
+      return false;
     }
   }
 
@@ -225,6 +225,11 @@ export function checkAny(
   changedFiles: string[]
 ): boolean {
   core.debug(`  checking "any" patterns`);
+  if (!Object.keys(matchConfigs).length) {
+    core.debug(`  no "any" patterns to check`);
+    return false;
+  }
+
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
       if (checkAnyBranch(matchConfig.baseBranch, 'base')) {
@@ -255,6 +260,11 @@ export function checkAll(
   changedFiles: string[]
 ): boolean {
   core.debug(` checking "all" patterns`);
+  if (!Object.keys(matchConfigs).length) {
+    core.debug(`  no "all" patterns to check`);
+    return false;
+  }
+
   for (const matchConfig of matchConfigs) {
     if (matchConfig.baseBranch) {
       if (!checkAllBranch(matchConfig.baseBranch, 'base')) {


### PR DESCRIPTION
This came up in a dicussion in my PR that made me think that I'd actually got the config structure wrong, and that it wasn't actually going to be as flexible or work the way that people expected it to. So I've changed the config again:

Changes the config so that `any` and `all` keys are applicable to each option. 
```yml
label:
  - any: 
    - changed-files: ['list', 'of', 'globs']
    - base-branch: ['list', 'of', 'regexps']
    - head-branch: ['list', 'of', 'regexps']
  - all:
    - changed-files: ['list', 'of', 'globs']
    - base-branch: ['list', 'of', 'regexps']
    - head-branch: ['list', 'of', 'regexps']
```

I have updated the readme and added more tests to cover these new cases.